### PR TITLE
Per-site tracking

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -39,6 +39,11 @@ class Module extends AbstractModule
             'form.add_elements',
             [$this, 'handleMainSettings']
         );
+        $sharedEventManager->attach(
+            \Omeka\Form\SiteSettingsForm::class,
+            'form.add_elements',
+            [$this, 'handleSiteSettings']
+        );
     }
 
     public function appendAnalyticsSnippet(ViewEvent $viewEvent): void

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -5,12 +5,15 @@ return [
     'form_elements' => [
         'invokables' => [
             Form\SettingsFieldset::class => Form\SettingsFieldset::class,
+            Form\SiteSettingsFieldset::class => Form\SiteSettingsFieldset::class,
         ],
     ],
     'analyticssnippet' => [
         'settings' => [
-            'analyticssnippet_inline_public' => '',
             'analyticssnippet_inline_admin' => '',
+        ],
+        'site_settings' => [
+            'analyticssnippet_inline_public' => '',
         ],
         'trackers' => [
             'default' => Tracker\InlineScript::class,

--- a/config/module.ini
+++ b/config/module.ini
@@ -8,5 +8,5 @@ author_link  = "https://gitlab.com/Daniel-KM"
 module_link  = "https://gitlab.com/Daniel-KM/Omeka-S-module-AnalyticsSnippet"
 support_link = "https://gitlab.com/Daniel-KM/Omeka-S-module-AnalyticsSnippet/-/issues"
 configurable = false
-version      = "3.3.3.1"
+version      = "3.4"
 omeka_version_constraint = "^3.0.0"

--- a/src/Form/SiteSettingsFieldset.php
+++ b/src/Form/SiteSettingsFieldset.php
@@ -4,7 +4,7 @@ namespace AnalyticsSnippet\Form;
 use Laminas\Form\Element;
 use Laminas\Form\Fieldset;
 
-class SettingsFieldset extends Fieldset
+class SiteSettingsFieldset extends Fieldset
 {
     protected $label = 'Analytics Snippet'; // @translate
 
@@ -12,17 +12,17 @@ class SettingsFieldset extends Fieldset
     {
         $this
             ->add([
-                'name' => 'analyticssnippet_inline_admin',
+                'name' => 'analyticssnippet_inline_public',
                 'type' => Element\Textarea::class,
                 'options' => [
-                    'label' => 'Code to append to admin pages', // @translate
+                    'label' => 'Code to append to public pages', // @translate
                     'info' => 'Don’t forget to add the tags <script> and </script> for javascript.', // @translate
                 ],
                 'attributes' => [
-                    'id' => 'analyticssnippet-inline-admin',
+                    'id' => 'analyticssnippet-inline-public',
                     'rows' => 5,
                     'placeholder' => '<script>
-console.log("Analytics Snippet ready for admin!");
+console.log("Analytics Snippet ready!");
 </script>',
                 ],
             ])


### PR DESCRIPTION
I moved the public tracking code setting from the global settings to the site settings page. This allows for a single Omeka S installation utilized by multiple organizations or domains to get their own tracking solution if desired